### PR TITLE
Update eventHandler.cfc

### DIFF
--- a/lib/eventHandler.cfc
+++ b/lib/eventHandler.cfc
@@ -18,7 +18,7 @@ component  extends="mura.plugin.pluginGenericEventHandler" output="false"
 		var siteManager=getBean("settingsManager");
 	  	siteManager.injectMethod("createCacheFactory",createCacheFactory);	
 
-		var rs=siteManager.getList();
+		var rs=variables.pluginConfig.getAssignedSites();
 		var cacheStruct={};
 		for(var i=1; i <= rs.recordcount; i++){
 			cacheStruct={


### PR DESCRIPTION
We've run into conflicts because the external cache is being used for every site, not just the sites that have this plugin assigned. This has caused some issues and confusion. Let's discuss further if this might have some wider implications but we're in the process of testing this change right now.
