### PR TITLE
Fixing incorrect siteid variable when setting cacheFactories

### DIFF
--- a/lib/eventHandler.cfc
+++ b/lib/eventHandler.cfc
@@ -26,7 +26,7 @@ component  extends="mura.plugin.pluginGenericEventHandler" output="false"
 				output=createCacheFactory(name='output',siteid=rs.siteid[i])
 			};
 
-			siteManager.getSite(rs.siteid).setCacheFactories(cacheStruct);	
+			siteManager.getSite(rs.siteid[i]).setCacheFactories(cacheStruct);	
 		}
 	}
 	


### PR DESCRIPTION
The rs.siteid variable needs to be rs.siteid[i] in line https://github.com/blueriver/MuraCache/blob/master/lib/eventHandler.cfc#L29.  Without this fix all cacheFactories actually point to only one siteid in the plugins assigned sites.