### PR TITLE
Allow instance-specific caches, plus Lucee 5 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ This is an alpha [Mura CMS](http://www.getmura.com) plugin that enables Mura to 
 
 Requires Mura 5.4.4602+.
 
+##Instance Name
+It may be that you have multiple instances of Mura on a server which share SiteIDs - for example, you may have more than one multi-lingual website, each of which has SiteIDs of "en" and "de".
+
+Normally, caches for these sites would clash as they would have the same name; however, if you go into the plugin settings you can optionally assign a name to each instance, allowing each site's cache to be properly segregated.
+
 ##Lucee Only
 In Lucee you will need to explicitly create two caches. One named **data** and another named **output** before installing the plugin.
 
@@ -18,4 +23,18 @@ So for the **default** site, the cache names would look like this:
   ```
   default-data
   default-output
+  ```
+
+If you have specified an instance name in the plugin options, the cache name syntax would be:
+
+  ```
+  {InstanceName}-{SiteID}-data
+  {InstanceName}-{SiteID}-output
+  ```
+
+So for the **default** site on an instance named "myInstance", the cache names would look like this:
+
+  ```
+  myInstance-default-data
+  myInstance-default-output
   ```

--- a/lib/cache/cacheAdobe.cfc
+++ b/lib/cache/cacheAdobe.cfc
@@ -24,6 +24,10 @@ component  extends="cacheBase" output="false" {
 	public any function init(){
 		variables.cacheName=arguments.siteID & "-" &arguments.name;
 
+		if (structkeyexists(arguments, "instanceName") and len(arguments.instanceName)) {
+			variables.cacheName=arguments.instanceName & "-" & variables.cacheName;
+		}
+
 		if( Val(ListFirst(server.coldfusion.productversion)) >= 10 
 			&& !cacheRegionExists(variables.cacheName) ) {
 				cacheRegionNew(variables.cacheName);

--- a/lib/cache/cacheLucee.cfc
+++ b/lib/cache/cacheLucee.cfc
@@ -23,6 +23,10 @@ component  extends="cacheBase" output="false" {
 	public any function init(){
 		
 		variables.cacheName=arguments.siteID & "-" & arguments.name;
+
+		if (structkeyexists(arguments, "instanceName") and len(arguments.instanceName)) {
+			variables.cacheName=arguments.instanceName & "-" & variables.cacheName;
+		}
 		
 		try
         {

--- a/lib/cache/cacheLucee.cfc
+++ b/lib/cache/cacheLucee.cfc
@@ -44,14 +44,14 @@ component  extends="cacheBase" output="false" {
 		return cacheGetAll(filter="", cacheName=variables.cacheName);
 	}
 	
-	public any function put(key,value,timespan=1,idleTime=1){
+	public any function put(key,value,timespan=createtimespan(1,0,0,0),idleTime=createtimespan(1,0,0,0)){
 		
 		if(arguments.timespan eq ""){
-			arguments.timespan=1;
+			arguments.timespan=createtimespan(1,0,0,0);
 		}
 		
 		if(arguments.idleTime eq ""){
-			arguments.idleTime=1;
+			arguments.idleTime=createtimespan(1,0,0,0);
 		}
 		
 		cachePut(id=arguments.key, 

--- a/lib/cacheFactory.cfc
+++ b/lib/cacheFactory.cfc
@@ -24,13 +24,13 @@ component extends="mura.Factory" output="false" {
 		return this;
 	}
 	
-	public any function set(key,context,timespan=1,idleTime=1) {
+	public any function set(key,context,timespan=createtimespan(1,0,0,0),idleTime=createtimespan(1,0,0,0)) {
 		
 		variables.collection.put( getHashKey( arguments.key ), arguments.context, arguments.timespan, arguments.idleTime );
 			
 	}
 	
-	public any function get(key,context,timespan=1,idleTime=1) {
+	public any function get(key,context,timespan=createtimespan(1,0,0,0),idleTime=createtimespan(1,0,0,0)) {
 		
 		if ( !has( arguments.key ) && isDefined("arguments.context") ) {	
 			set( arguments.key, arguments.context,arguments.timespan,arguments.idleTime );

--- a/lib/eventHandler.cfc
+++ b/lib/eventHandler.cfc
@@ -19,11 +19,12 @@ component  extends="mura.plugin.pluginGenericEventHandler" output="false" {
 	  siteManager.injectMethod("createCacheFactory",createCacheFactory);	
 
 		var rs=variables.pluginConfig.getAssignedSites();
+		var instanceName=variables.pluginConfig.getSetting("instanceName");
 		var cacheStruct={};
 		for(var i=1; i <= rs.recordcount; i++){
 			cacheStruct={
-				data=createCacheFactory(name='data',siteid=rs.siteid[i]),
-				output=createCacheFactory(name='output',siteid=rs.siteid[i])
+				data=createCacheFactory(name='data',siteid=rs.siteid[i],instanceName=instanceName),
+				output=createCacheFactory(name='output',siteid=rs.siteid[i],instanceName=instanceName)
 			};
 
 			siteManager.getSite(rs.siteid[i]).setCacheFactories(cacheStruct);	

--- a/plugin/config.xml
+++ b/plugin/config.xml
@@ -22,7 +22,21 @@
 <provider>Blue River</provider>
 <providerURL>http://blueriver.com</providerURL>
 <category>Application</category>
-<settings/>
+<settings>
+    <setting>
+        <name>instanceName</name>
+        <label>Instance name (optional)</label>
+        <hint>If provided, cache will be have {InstanceName}- added to the start of its name</hint>
+        <type>text</type>
+        <required>false</required>
+        <validation>regex</validation>
+        <regex>^[a-zA-Z0-9]+$</regex>
+        <message>Please enter only letters and numbers</message>
+        <defaultValue></defaultValue>
+        <optionList></optionList>
+        <optionLabelList></optionLabelList>
+    </setting>
+</settings>
 <eventHandlers>
 	<eventHandler event="onApplicationLoad" component="lib.eventHandler" persist="false"/>
 </eventHandlers>


### PR DESCRIPTION
## Instance specific caches

Allows an optional instance name to be specified in plugin settings, which will be prepended to cache name - i.e.:

```
{InstanceName}-{SiteID}-data
{InstanceName}-{SiteID}-output
```

This is useful if you have a couple of Mura installs on the same server which share siteids, for instance if you have 2 multilingual sites, each of which has siteids "en" and "de". Normally, these caches would clash...
## Lucee 5 Fix

NOTE: this has been identified as a Lucee bug, so this fix may not be necessary once it's been resolved:
https://luceeserver.atlassian.net/browse/LDEV-875

Lucee 5 (and maybe earlier, I haven't tested) throws a fit if the timespan values passed in to cachePut() are not actual timespans:

```
java.lang.Double cannot be cast to lucee.runtime.type.dt.TimeSpan 
Code: 0 
Type: java.lang.ClassCastException
```

```
Column: 0
ID: ??
Line: 59
Raw Trace: muracache.lib.cache.cachelucee_cfc$cf.udfCall(/Developer/git/mura-cricket/plugins/MuraCache/lib/cache/cacheLucee.cfc:59)
Template: /Developer/git/mura-cricket/plugins/MuraCache/lib/cache/cacheLucee.cfc
Type: cfml
```

Changing the default values from 1 to createtimespan(1,0,0,0) seems to fix the issue.
